### PR TITLE
Fix SetEncryptionAlgorithm not working when using AddSignerChain

### DIFF
--- a/sign.go
+++ b/sign.go
@@ -151,7 +151,9 @@ func (sd *SignedData) AddSignerChain(ee *x509.Certificate, pkey crypto.PrivateKe
 	h := hash.New()
 	h.Write(sd.data)
 	sd.messageDigest = h.Sum(nil)
-	encryptionOid, err := getOIDForEncryptionAlgorithm(pkey, sd.digestOid)
+    if sd.encryptionOid == nil {
+        sd.encryptionOid, err = getOIDForEncryptionAlgorithm(pkey, sd.digestOid)
+    }
 	if err != nil {
 		return err
 	}
@@ -183,7 +185,7 @@ func (sd *SignedData) AddSignerChain(ee *x509.Certificate, pkey crypto.PrivateKe
 		AuthenticatedAttributes:   finalAttrs,
 		UnauthenticatedAttributes: finalUnsignedAttrs,
 		DigestAlgorithm:           pkix.AlgorithmIdentifier{Algorithm: sd.digestOid},
-		DigestEncryptionAlgorithm: pkix.AlgorithmIdentifier{Algorithm: encryptionOid},
+		DigestEncryptionAlgorithm: pkix.AlgorithmIdentifier{Algorithm: sd.encryptionOid},
 		IssuerAndSerialNumber:     ias,
 		EncryptedDigest:           signature,
 		Version:                   1,


### PR DESCRIPTION
This PR adds support for SetEncryptionAlgorithm when using AddSignerChain. It is intended to replicate the changes introduced in: https://github.com/dancannon/pkcs7/commit/6399fbdb913567bb7c042ba8dd4e930d93c94102.